### PR TITLE
feat: embed yt-dlp binary and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,33 @@ on:
       - "v*"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: Install dependencies
+        run: |
+          go get github.com/bogem/id3v2
+          go mod tidy
+
+      - name: Create bin directory and download yt-dlp
+        run: |
+          mkdir -p bin
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o bin/yt-dlp
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe -o bin/yt-dlp.exe
+          chmod +x bin/yt-dlp
+
+      - name: Run tests
+        run: go test -v ./...
+
   release:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,6 +43,11 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+
+      - name: Install dependencies
+        run: |
+          go get github.com/bogem/id3v2
+          go mod tidy
 
       - name: Create bin directory
         run: mkdir -p bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,54 +5,40 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.21"
 
-      - name: Build for Windows
-        run: |
-          GOOS=windows GOARCH=amd64 go build -o dist/yt2mp3_windows_amd64.exe
-          cd dist && zip yt2mp3_windows_amd64.zip yt2mp3_windows_amd64.exe && cd ..
+      - name: Create bin directory
+        run: mkdir -p bin
 
-      - name: Build for macOS
+      - name: Download yt-dlp binaries
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o dist/yt2mp3_darwin_amd64
-          cd dist && zip yt2mp3_darwin_amd64.zip yt2mp3_darwin_amd64 && cd ..
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o bin/yt-dlp
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe -o bin/yt-dlp.exe
+          chmod +x bin/yt-dlp
 
-      - name: Build for Linux
+      - name: Build for all platforms
         run: |
-          GOOS=linux GOARCH=amd64 go build -o dist/yt2mp3_linux_amd64
-          cd dist && zip yt2mp3_linux_amd64.zip yt2mp3_linux_amd64 && cd ..
+          GOOS=darwin GOARCH=amd64 go build -o dist/yt2mp3-darwin-amd64
+          GOOS=darwin GOARCH=arm64 go build -o dist/yt2mp3-darwin-arm64
+          GOOS=windows GOARCH=amd64 go build -o dist/yt2mp3-windows-amd64.exe
+          GOOS=linux GOARCH=amd64 go build -o dist/yt2mp3-linux-amd64
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist/yt2mp3_windows_amd64.zip
-            dist/yt2mp3_darwin_amd64.zip
-            dist/yt2mp3_linux_amd64.zip
-          body: |
-            ## yt2mp3 ${{ github.ref_name }}
-
-            YouTube to MP3 converter written in Go.
-
-            ### Features
-            - Download YouTube videos and convert to MP3
-            - No external dependencies required
-            - Cross-platform support (Windows, macOS, Linux)
-            - Simple command-line interface
-
-            ### Downloads
-            - Windows: `yt2mp3_windows_amd64.zip`
-            - macOS: `yt2mp3_darwin_amd64.zip`
-            - Linux: `yt2mp3_linux_amd64.zip`
+            dist/yt2mp3-darwin-amd64
+            dist/yt2mp3-darwin-arm64
+            dist/yt2mp3-windows-amd64.exe
+            dist/yt2mp3-linux-amd64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,15 @@
 name: Test
 
 on:
-  pull_request:
-    branches: [main]
   push:
-    branches: [main]
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
-    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,11 +17,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
-          check-latest: true
+          go-version: "1.21"
 
       - name: Install dependencies
-        run: go mod download
+        run: |
+          go get github.com/bogem/id3v2
+          go mod tidy
+
+      - name: Create bin directory and download yt-dlp
+        run: |
+          mkdir -p bin
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o bin/yt-dlp
+          curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe -o bin/yt-dlp.exe
+          chmod +x bin/yt-dlp
 
       - name: Run tests
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ go.work
 *.swp
 *.swo
 
-# ビルドディレクトリ
-bin/
+# Distribution directory
 dist/ 

--- a/main.go
+++ b/main.go
@@ -1,15 +1,78 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/bogem/id3v2"
 	"github.com/spf13/cobra"
 )
+
+//go:embed bin/*
+var binaries embed.FS
+
+// extractYtDlp extracts the embedded yt-dlp binary to a temporary file
+func extractYtDlp() (string, error) {
+	// Determine the binary name based on the OS
+	binaryName := "yt-dlp"
+	if runtime.GOOS == "windows" {
+		binaryName = "yt-dlp.exe"
+	}
+
+	// Read the embedded binary
+	data, err := binaries.ReadFile(filepath.Join("bin", binaryName))
+	if err != nil {
+		return "", fmt.Errorf("failed to read embedded yt-dlp: %v", err)
+	}
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "yt-dlp-*"+filepath.Ext(binaryName))
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer tmpFile.Close()
+
+	// Make the file executable
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpFile.Name(), 0755); err != nil {
+			return "", fmt.Errorf("failed to make yt-dlp executable: %v", err)
+		}
+	}
+
+	// Write the binary data
+	if _, err := tmpFile.Write(data); err != nil {
+		return "", fmt.Errorf("failed to write yt-dlp: %v", err)
+	}
+
+	return tmpFile.Name(), nil
+}
+
+// sanitizeFilename removes or replaces invalid characters from the filename
+// and ensures the filename length is within acceptable limits
+func sanitizeFilename(filename string) string {
+	// Replace invalid characters with underscore
+	invalidChars := []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"}
+	result := filename
+	for _, char := range invalidChars {
+		result = strings.ReplaceAll(result, char, "_")
+	}
+
+	// Trim spaces from start and end
+	result = strings.TrimSpace(result)
+
+	// Ensure filename is not too long (max 200 chars including extension)
+	if len(result) > 200 {
+		ext := filepath.Ext(result)
+		result = result[:200-len(ext)] + ext
+	}
+
+	return result
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "yt2mp3 [URL]",
@@ -25,9 +88,16 @@ var rootCmd = &cobra.Command{
 		}
 		defer os.RemoveAll(tempDir)
 
+		// Extract yt-dlp binary
+		ytdlpPath, err := extractYtDlp()
+		if err != nil {
+			return err
+		}
+		defer os.Remove(ytdlpPath)
+
 		// Download audio using yt-dlp
 		fmt.Println("Downloading audio...")
-		ytdlCmd := exec.Command("yt-dlp",
+		ytdlCmd := exec.Command(ytdlpPath,
 			"--extract-audio",
 			"--audio-format", "mp3",
 			"--audio-quality", "0",
@@ -47,21 +117,19 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("no files downloaded")
 		}
 
-		// Move the file to current directory
+		// Use the downloaded file
 		downloadedFile := filepath.Join(tempDir, files[0].Name())
-		targetFile := files[0].Name()
+		targetFile := sanitizeFilename(files[0].Name())
 
-		// Read file for ID3 tags
+		// Open file for ID3 tag editing
 		tag, err := id3v2.Open(downloadedFile, id3v2.Options{Parse: true})
 		if err != nil {
 			return fmt.Errorf("failed to open MP3 file for tagging: %v", err)
 		}
 
 		// Set basic tags
-		tag.SetTitle(strings.TrimSuffix(files[0].Name(), filepath.Ext(files[0].Name())))
+		tag.SetTitle(strings.TrimSuffix(targetFile, filepath.Ext(targetFile)))
 		tag.SetAlbum("YouTube")
-
-		// Add YouTube URL as comment
 		tag.AddCommentFrame(id3v2.CommentFrame{
 			Language:    "eng",
 			Description: "YouTube URL",
@@ -73,6 +141,11 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to save ID3 tags: %v", err)
 		}
 		tag.Close()
+
+		// QuickTime互換のため、ID3タグバージョンをv2.3に固定する
+		if err = fixID3Version(downloadedFile); err != nil {
+			return fmt.Errorf("failed to fix ID3 version: %v", err)
+		}
 
 		// Move file to current directory
 		if err := os.Rename(downloadedFile, targetFile); err != nil {
@@ -89,4 +162,39 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+// fixID3Version opens the MP3 file and changes the tag version from ID3v2.4 to ID3v2.3 if needed.
+func fixID3Version(filename string) error {
+	f, err := os.OpenFile(filename, os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	header := make([]byte, 10)
+	n, err := f.Read(header)
+	if err != nil || n != 10 {
+		return fmt.Errorf("failed to read header")
+	}
+
+	if string(header[0:3]) != "ID3" {
+		// No ID3 tag present, nothing to fix
+		return nil
+	}
+
+	// If version is 2.4 (0x04), change it to 2.3 (0x03)
+	if header[3] == 4 {
+		header[3] = 3
+		_, err = f.Seek(0, 0)
+		if err != nil {
+			return err
+		}
+		_, err = f.Write(header)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/bogem/id3v2"
 	"github.com/spf13/cobra"
 	"github.com/wader/goutubedl"
 )
@@ -25,7 +27,9 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to get video info: %v", err)
 		}
 
-		filename := sanitizeFilename(result.Info.Title) + ".mp3"
+		filename := sanitizeFilename(result.Info.Title)
+		tempFile := filename + ".temp"
+		mp3File := filename + ".mp3"
 		fmt.Printf("Downloading: %s\n", result.Info.Title)
 
 		// Download the best audio format
@@ -35,18 +39,34 @@ var rootCmd = &cobra.Command{
 		}
 		defer downloadResult.Close()
 
-		outFile, err := os.Create(filename)
+		outFile, err := os.Create(tempFile)
 		if err != nil {
-			return fmt.Errorf("failed to create output file: %v", err)
+			return fmt.Errorf("failed to create temporary file: %v", err)
 		}
-		defer outFile.Close()
+		defer func() {
+			outFile.Close()
+			os.Remove(tempFile)
+		}()
 
 		_, err = io.Copy(outFile, downloadResult)
 		if err != nil {
 			return fmt.Errorf("failed to save file: %v", err)
 		}
+		outFile.Close()
 
-		fmt.Printf("Successfully downloaded and converted to: %s\n", filename)
+		// Convert to MP3 using ffmpeg
+		fmt.Println("Converting to MP3...")
+		ffmpegCmd := exec.Command("ffmpeg", "-i", tempFile, "-codec:a", "libmp3lame", "-q:a", "0", mp3File)
+		if output, err := ffmpegCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to convert to MP3: %v\nOutput: %s", err, output)
+		}
+
+		// Add ID3 tags
+		if err := addID3Tags(mp3File, result.Info); err != nil {
+			return fmt.Errorf("failed to add ID3 tags: %v", err)
+		}
+
+		fmt.Printf("Successfully downloaded and converted to: %s\n", mp3File)
 		return nil
 	},
 }
@@ -70,6 +90,33 @@ func sanitizeFilename(filename string) string {
 	}
 
 	return filename
+}
+
+func addID3Tags(filename string, info goutubedl.Info) error {
+	tag, err := id3v2.Open(filename, id3v2.Options{Parse: true})
+	if err != nil {
+		return fmt.Errorf("failed to open MP3 file for tagging: %v", err)
+	}
+	defer tag.Close()
+
+	// Set basic tags
+	tag.SetTitle(info.Title)
+	tag.SetArtist(info.Channel)
+	tag.SetAlbum("YouTube")
+
+	// Add YouTube URL as comment
+	tag.AddCommentFrame(id3v2.CommentFrame{
+		Language:    "eng",
+		Description: "YouTube URL",
+		Text:        info.WebpageURL,
+	})
+
+	// Save the tags
+	if err = tag.Save(); err != nil {
+		return fmt.Errorf("failed to save ID3 tags: %v", err)
+	}
+
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
## 変更内容

- yt-dlpバイナリを実行ファイルに埋め込み
- GitHub Actionsによるリリースワークフローを追加
- ファイル名のサニタイズ処理を追加
- QuickTime互換のためのID3タグバージョン修正

## 動作確認項目

- [ ] テストが全て通ること
- [ ] Mac/Windowsで動作すること
- [ ] ファイル名が正しくサニタイズされること
- [ ] QuickTimeでMP3が再生できること

## その他

- リリース時にyt-dlpバイナリが同梱されるため、ユーザーは別途インストールする必要がありません
- 各プラットフォーム（Mac Intel/ARM, Windows, Linux）用のバイナリが自動生成されます